### PR TITLE
After authorizing, reload Root Links as the links/commands may have changed.

### DIFF
--- a/TeamSnapSDK/TSDKTeamSnap.m
+++ b/TeamSnapSDK/TSDKTeamSnap.m
@@ -73,7 +73,7 @@
             }
         }];
     } else {
-        [self processInitialConnectionWithConfiguration:nil completion:completion];
+        [self processInitialConnectionWithConfiguration:configuration completion:completion];
     }
 }
 

--- a/TeamSnapSDK/TSDKTeamSnap.m
+++ b/TeamSnapSDK/TSDKTeamSnap.m
@@ -79,7 +79,7 @@
 
 - (void)loginWithOAuthToken:(NSString *)OAuthToken completion:(void (^)(BOOL success, NSError *error))completion {
     [self setOAuthToken:OAuthToken];
-    [self connectWithConfiguration:nil completion:completion];
+    [self connectWithConfiguration:[TSDKRequestConfiguration requestConfigurationWithForceReload:YES] completion:completion];
 }
 
 - (void)logout {

--- a/TeamSnapSDK/TSDKTeamSnap.m
+++ b/TeamSnapSDK/TSDKTeamSnap.m
@@ -181,7 +181,7 @@
         }
     };
     
-    if (self.rootLinks) {
+    if (self.rootLinks && configuration.forceReload == NO) {
         [self.rootLinks getSchemasWithConfiguration:configuration completion:schemaCompletionBlock];
     } else {
         TSDKTeamSnap __weak *weakSelf = self;


### PR DESCRIPTION
Root Links have different content based on auth status. This insures that Root Links is refreshed after a successful login. Resolves iOSS-254.