### PR TITLE
Properly dispatch UIKit functions to main thread

### DIFF
--- a/TeamSnapSDK/SDK/DataLayer/TSDKNetworkActivityIndicator.m
+++ b/TeamSnapSDK/SDK/DataLayer/TSDKNetworkActivityIndicator.m
@@ -29,17 +29,26 @@
 - (void)startActivity {
     @synchronized(self) {
         _numberOfActivities++;
-        [UIApplication sharedApplication].networkActivityIndicatorVisible = YES;
     }
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [UIApplication sharedApplication].networkActivityIndicatorVisible = YES;
+    });
 }
 
 - (void)stopActivity {
+    
+    BOOL showIndicator;
     @synchronized(self) {
         if (_numberOfActivities) {
             _numberOfActivities--;
         }
-        [UIApplication sharedApplication].networkActivityIndicatorVisible = (_numberOfActivities > 0);
+        showIndicator = (_numberOfActivities > 0);
     }
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [UIApplication sharedApplication].networkActivityIndicatorVisible = showIndicator;
+    });
 }
 
 @end


### PR DESCRIPTION
Some UIKit methods were being called from background threads. This ensures they are called from the correct main thread. No clue if this will speed up those background queues or if this just means our network activity indicator will start working again.

There does not appear to be anymore UIKit API misuse on background threads in my audit of the application.