### PR TITLE
Possibly resolving threading issue with template storage

### DIFF
--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.m
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.m
@@ -31,12 +31,9 @@ static NSMutableDictionary *_queryDictionary;
 static NSMutableDictionary *_classURLs;
 
 +(NSDictionary *)templateForClass:(NSString *)className {
-    if (_templates) {
-        @synchronized (self.templates) {
-            return [_templates objectForKey:className];
-        }
+    @synchronized (self.templates) {
+        return [self.templates objectForKey:className];
     }
-    return nil;
 }
 
 - (NSMutableDictionary *)cachedDatesLookup {
@@ -55,19 +52,22 @@ static NSMutableDictionary *_classURLs;
 }
 
 +(void)setTemplate:(NSDictionary *)template forClass:(NSString *)className {
+    NSDictionary *templateCopy = [template copy];
+
     @synchronized (self.templates) {
-        if (template) {
-            [self.templates setObject:template forKey:className];
+        if (templateCopy) {
+            [self.templates setObject:templateCopy forKey:className];
         } else {
-            [_templates removeObjectForKey:className];
+            [self.templates removeObjectForKey:className];
         }
     }
 }
 
 +(NSMutableDictionary *)templates {
-    if (!_templates) {
-        _templates = [[NSMutableDictionary alloc] init];
-    }
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _templates = [NSMutableDictionary dictionary];
+    });
     return _templates;
 }
 


### PR DESCRIPTION
I needed a short break from overview cards. This one is a bit of a guess as it's not reproducible.

https://fabric.io/teamsnap/ios/apps/com.teamsnap.ios/issues/59bc54a5be077a4dccb1d819?time=last-seven-days

The stack trace for this crash in crashlytics for 3.14 shows two threads accessing the static storage `_templates` at the same time. One on a read for `+templatesForClass:` and the other for a write on `+setTemplate:forClass:`. The second thread waits properly in a mutex lock per the synchronization for the read. The thread that has the lock crashes with `EXC_BAD_ACCESS KERN_INVALID_ADDRESS` indicating it's trying to reference deallocated memory. The _only_ memory that it could possibly be reading that it has no direct control over is the passed in template. Everything else is controlled internally and is locked on by the synchronization. In fact, as static storage, we're not even prematurely tearing down `_templates`, so it can't be that.

To mitigate possibly crashing while associating the template dictionary with our storage, I've created a shallow copy of the dictionary, which should give us our own copy to manipulate and store since we want this date for our own internal purposes.

All other changes are cleaning up references to `self.templates` and using `dispatch_once` for the `_templates` storage creation. All these changes should be pretty minimally invasive while being a little safer to access and store in the static storage.

What do you think?