### PR TITLE
Present percentages with no decimal values, e.g. 100% - not 100.0%

### DIFF
--- a/TeamSnapSDK/SDK/DataTypes/Statistics/TSDKStatistic.m
+++ b/TeamSnapSDK/SDK/DataTypes/Statistics/TSDKStatistic.m
@@ -24,8 +24,12 @@
 
 - (NSString *)displayStringForStatisticValue:(NSNumber *)statValue {
 
-    if ((self.alwaysDisplayDecimals == false) && [statValue isWholeNumber] && ![self isPercentage]) {
-        return [NSString stringWithFormat:@"%ld", (long)[statValue integerValue]];
+    if ((self.alwaysDisplayDecimals == false) && [statValue isWholeNumber]) {
+        if (self.isPercentage) {
+            return [NSString stringWithFormat:@"%ld%%", (long)statValue.integerValue * 100];
+        } else {
+            return [NSString stringWithFormat:@"%ld", (long)statValue.integerValue];
+        }
     } else {
         NSString *formatString = [NSString stringWithFormat:@"%%.%ldf", (long)self.precision];
         if ([self isPercentage]) {


### PR DESCRIPTION
Note that this removal of the decimal place only occurs for whole number values (e.g. a stat value of `1` will display as `100%` and `2` will display as `200%`. Previous code would add the decimal place for all percentages so we would have unnecessarily precise values like `100.0%`.