### PR TITLE
Remove persistent root links cache

### DIFF
--- a/TeamSnapSDK/SDK/Cache/TSPCache.m
+++ b/TeamSnapSDK/SDK/Cache/TSPCache.m
@@ -10,7 +10,7 @@
 
 NSURL static *_rootPath = nil;
 NSURL static *_basePath = nil;
-NSUInteger static _maxCacheAgeMinutes = 60; // ~1 month
+NSUInteger static _maxCacheAgeMinutes = 60; // ~1 hour
 NSFileManager static *_fileManager = nil;
 
 @implementation TSPCache

--- a/TeamSnapSDK/TSDKTeamSnap.m
+++ b/TeamSnapSDK/TSDKTeamSnap.m
@@ -161,15 +161,6 @@
     }
 }
 
-- (TSDKRootLinks *)rootLinks {
-    if(!_rootLinks) {
-        if([[TSPCache objectOfClass:[TSDKRootLinks class] withId:nil] isKindOfClass:[TSDKRootLinks class]]) {
-             _rootLinks = (TSDKRootLinks *)[TSPCache objectOfClass:[TSDKRootLinks class] withId:nil];
-        }
-    }
-    return _rootLinks;
-}
-
 - (void)rootLinksWithConfiguration:(TSDKRequestConfiguration *)configuration completion:(TSDKRootLinkCompletionBlock)completion {
     TSDKSimpleCompletionBlock schemaCompletionBlock  = ^(BOOL success, NSError *error) {
         if (success) {


### PR DESCRIPTION
The Root Links cache was currently set to 1 hour. I believe it was functionally doing very little. I removed the cache and intend that root links will last throughout an app session, unless explicitly refreshed using a refresh configuration. Now it just uses the in memory property.