### PR TITLE
If root links request fails, use the cached object

### DIFF
--- a/TeamSnapSDK/TSDKTeamSnap.m
+++ b/TeamSnapSDK/TSDKTeamSnap.m
@@ -87,14 +87,6 @@
     self.OAuthToken = nil;
 }
 
-- (TSDKRootLinks *)rootLinks {
-    if(!_rootLinks) {
-        // load cached copy if available
-        _rootLinks = [TSPCache objectOfClass:[TSDKRootLinks class] withId:@""];
-    }
-    return _rootLinks;
-}
-
 - (void)configureForCombinedContactFeature {
     self.useCombinedContactCard = YES;
 }
@@ -192,6 +184,11 @@
             
                 [self.rootLinks getSchemasWithConfiguration:configuration completion:schemaCompletionBlock];
             } else {
+                TSDKCollectionObject *cachedObject = [TSPCache objectOfClass:[TSDKRootLinks class] withId:@""];
+                if([cachedObject isKindOfClass:[TSDKRootLinks class]]) {
+                    weakSelf.rootLinks = [TSPCache objectOfClass:[TSDKRootLinks class] withId:@""];
+                }
+                
                 if (completion) {
                     completion(weakSelf.rootLinks, error);
                 }

--- a/TeamSnapSDK/TSDKTeamSnap.m
+++ b/TeamSnapSDK/TSDKTeamSnap.m
@@ -87,6 +87,14 @@
     self.OAuthToken = nil;
 }
 
+- (TSDKRootLinks *)rootLinks {
+    if(!_rootLinks) {
+        // load cached copy if available
+        _rootLinks = [TSPCache objectOfClass:[TSDKRootLinks class] withId:@""];
+    }
+    return _rootLinks;
+}
+
 - (void)configureForCombinedContactFeature {
     self.useCombinedContactCard = YES;
 }

--- a/TeamSnapSDK/TSDKTeamSnap.m
+++ b/TeamSnapSDK/TSDKTeamSnap.m
@@ -184,9 +184,9 @@
             
                 [self.rootLinks getSchemasWithConfiguration:configuration completion:schemaCompletionBlock];
             } else {
-                TSDKCollectionObject *cachedObject = [TSPCache objectOfClass:[TSDKRootLinks class] withId:@""];
-                if([cachedObject isKindOfClass:[TSDKRootLinks class]]) {
-                    weakSelf.rootLinks = [TSPCache objectOfClass:[TSDKRootLinks class] withId:@""];
+                TSDKCollectionObject *cachedRootLinks = [TSPCache objectOfClass:[TSDKRootLinks class] withId:@""];
+                if([cachedRootLinks isKindOfClass:[TSDKRootLinks class]]) {
+                    weakSelf.rootLinks = cachedRootLinks;
                 }
                 
                 if (completion) {


### PR DESCRIPTION
If the root links network request fails and we have a disk cache of root links, populate the in-mem var.