### PR TITLE
Cache ObjectIdentifier

### DIFF
--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.m
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.m
@@ -230,6 +230,7 @@ static NSMutableDictionary *_classURLs;
 }
 
 - (void)setCollection:(TSDKCollectionJSON *)collection {
+    self._objectIdentifier = nil;
     _collection = collection;
     _lastUpdate = [NSDate date];
 }
@@ -715,10 +716,16 @@ static BOOL property_getTypeString( objc_property_t property, char *buffer ) {
 }
 
 - (BOOL)isNewObject {
-    if (([[[self collection] data] objectForKey:@"id"] == nil) || [[[[[self collection] data] objectForKey:@"id"] description] isEqualToString:@""] || [[[[self collection] data] objectForKey:@"id"] isEqual:[NSNull null]] || ([[[[self collection] data] objectForKey:@"id"] integerValue] == 0)) {
+    id rawIdentifier = self.collection.data[@"id"];
+    
+    if (rawIdentifier == nil ||
+        [[rawIdentifier description] isEqualToString:@""] ||
+        [rawIdentifier isEqual:[NSNull null]] ||
+        [rawIdentifier integerValue] == 0) {
         return YES;
     }
-    return FALSE;    
+    
+    return NO;
 }
 
 - (NSURL *)urlForSave {
@@ -762,7 +769,6 @@ static BOOL property_getTypeString( objc_property_t property, char *buffer ) {
                 if ([objects.collection isKindOfClass:[NSArray class]]) {
                     NSArray *returnedCollections = (NSArray *)objects.collection;
                     if ([returnedCollections count]==1) {
-                        weakSelf._objectIdentifier = nil;
                         [weakSelf setCollection:[returnedCollections objectAtIndex:0]];
                         [TSDKNotifications postNewObject:self];
                     } else {

--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.m
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.m
@@ -20,6 +20,7 @@
 @interface TSDKCollectionObject()
 
 @property (nonatomic, strong) NSMutableDictionary *cachedDatesLookup;
+@property (nonatomic, strong) NSString *_objectIdentifier;
 
 @end
 
@@ -519,10 +520,14 @@ static BOOL property_getTypeString( objc_property_t property, char *buffer ) {
 }
 
 - (NSString * _Nonnull)objectIdentifier {
-    if ((!self.collection.data[@"id"]) || ([self.collection.data[@"id"] isEqual:[NSNull null]])) {
-        return @"";
+    if (self._objectIdentifier == nil) {
+        // ObjectIdentifier could be a String or Int.
+        self._objectIdentifier = [self.collection.data[@"id"] description];
+        if ((self._objectIdentifier == nil) || [self._objectIdentifier isEqual:[NSNull null]]) {
+            self._objectIdentifier = @"";
+        }
     }
-    return [self objectIdentifierForKey:@"id"];
+    return self._objectIdentifier;
 }
 
 - (NSString * _Nonnull)objectIdentifierForKey:(NSString *)key {
@@ -754,6 +759,7 @@ static BOOL property_getTypeString( objc_property_t property, char *buffer ) {
                 if ([objects.collection isKindOfClass:[NSArray class]]) {
                     NSArray *returnedCollections = (NSArray *)objects.collection;
                     if ([returnedCollections count]==1) {
+                        weakSelf._objectIdentifier = nil;
                         [weakSelf setCollection:[returnedCollections objectAtIndex:0]];
                         [TSDKNotifications postNewObject:self];
                     } else {

--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.m
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.m
@@ -715,7 +715,10 @@ static BOOL property_getTypeString( objc_property_t property, char *buffer ) {
 }
 
 - (BOOL)isNewObject {
-    return ([[self objectIdentifier] isEqualToString:@""] || [[self objectIdentifier] integerValue] == 0);
+    if (([[[self collection] data] objectForKey:@"id"] == nil) || [[[[[self collection] data] objectForKey:@"id"] description] isEqualToString:@""] || [[[[self collection] data] objectForKey:@"id"] isEqual:[NSNull null]] || ([[[[self collection] data] objectForKey:@"id"] integerValue] == 0)) {
+        return YES;
+    }
+    return FALSE;    
 }
 
 - (NSURL *)urlForSave {


### PR DESCRIPTION
Cache objectIdentifier. 

Notes: ObjectIdentifier has always been read only (there is no setObjectIdentifier, and no dynamic property defined that would lead to a setter. 

The risk is anywhere that data["id"] was set directly, after objectdentifier was cached, and then objectIdentifier was read.

The most common use case is if the app creates an SDK object and saves it. For this we uncache _objectIdentifier.