### PR TITLE
Eager dynamic runtime method implementation assignment

### DIFF
--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.m
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.m
@@ -519,8 +519,8 @@ static void addImplementationForSelector(objc_property_t prop, SEL selector, Cla
             
             // Only synthesize dynamic properties
             if ([attributeComponents containsObject:@"D"]) {
-                if (sizeof(name) > 0 && [attributeComponents containsObject:@"R"] == NO) {
                     // Readwrite, synthesize setter and getter
+                if (strlen(name) > 0 && [attributeComponents containsObject:@"R"] == NO) {
                     
                     // construct setter
                     NSString *upperFirstCharString = [[NSString stringWithFormat:@"%c", name[0]] uppercaseString];

--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.m
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.m
@@ -449,33 +449,6 @@ static BOOL property_getTypeString( objc_property_t property, char *buffer ) {
     DLog(@"%@", output);
 }
 
-static Class originalImplementerOfProperty(objc_property_t property, Class subclass) {
-    unsigned int superCount = 0;
-    objc_property_t *superProperties = class_copyPropertyList([subclass superclass], &superCount);
-    
-    const char *propertyName = property_getName(property);
-    NSString *propertyNameString = [NSString stringWithUTF8String:propertyName];
-    
-    const char * propAttr = property_getAttributes(property);
-    for (int i = 0; i < superCount; i++) {
-        objc_property_t supes = superProperties[i];
-        const char *superName = property_getName(supes);
-        NSString *superPropertyName = [NSString stringWithUTF8String:superName];
-        const char *superAttr = property_getAttributes(supes);
-        
-        if ([superPropertyName isEqualToString:propertyNameString] && strcmp(propAttr, superAttr) == 0) {
-            // Superclass also has method
-            return originalImplementerOfProperty(property, [subclass superclass]);
-        }
-    }
-    
-    if (superProperties != NULL) {
-        free(superProperties);
-    }
-    
-    return subclass;
-}
-
 // Want this separate from DLog. When we know this is reliable, we can optionally remove
 //  these logging calls entirely.
 #if (0 && DEBUG)
@@ -542,7 +515,7 @@ static void addImplementationForSelector(objc_property_t prop, SEL selector, Cla
                         RuntimeLog(@"Attempting to add selector for setter: %@", NSStringFromSelector(setter));
                         addImplementationForSelector(prop, setter, self);
                     } else {
-                        RuntimeLog(@"Failed to construct selector for setter: %@", augmentedSetterString);
+                        RuntimeLog(@"Failed to construct selector for setter: %@", setterName);
                     }
                 }
                 

--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.m
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.m
@@ -519,15 +519,25 @@ static void addImplementationForSelector(objc_property_t prop, SEL selector, Cla
             
             // Only synthesize dynamic properties
             if ([attributeComponents containsObject:@"D"]) {
-                    // Readwrite, synthesize setter and getter
                 if (strlen(name) > 0 && [attributeComponents containsObject:@"R"] == NO) {
                     
-                    // construct setter
-                    NSString *upperFirstCharString = [[NSString stringWithFormat:@"%c", name[0]] uppercaseString];
-                    NSString *trimmedPropertyName = [propertyNameString substringFromIndex:1];
-                    NSString *augmentedSetterString = [NSString stringWithFormat:@"set%@%@:", upperFirstCharString, trimmedPropertyName];
+                    NSString *setterName = nil;
+                    for (NSString *attribute in attributeComponents) {
+                        if ([attribute hasPrefix:@"S"]) {
+                            // Has a custom setter, extract setter
+                            setterName = [attribute substringFromIndex:1];
+                        }
+                    }
                     
-                    SEL setter = NSSelectorFromString(augmentedSetterString);
+                    if (setterName == nil) {
+                        // Readwrite, synthesize setter
+                        // Construct setter
+                        NSString *upperFirstCharString = [[NSString stringWithFormat:@"%c", name[0]] uppercaseString];
+                        NSString *trimmedPropertyName = [propertyNameString substringFromIndex:1];
+                        setterName = [NSString stringWithFormat:@"set%@%@:", upperFirstCharString, trimmedPropertyName];
+                    }
+                    
+                    SEL setter = NSSelectorFromString(setterName);
                     if (setter != NULL) {
                         RuntimeLog(@"Attempting to add selector for setter: %@", NSStringFromSelector(setter));
                         addImplementationForSelector(prop, setter, self);


### PR DESCRIPTION
# This is EXPERIMENTAL
Even though I can't find anything wrong with it. Everything works and all tests pass. But this is the runtime, after all.

![https://media.giphy.com/media/l0IykOsxLECVejOzm/giphy.gif](https://media.giphy.com/media/l0IykOsxLECVejOzm/giphy.gif)

This, in theory, should simply switch our runtime assignment of method implementations from being lazily assigned in `- (BOOL)resolveInstanceMethod:` to being performed in `+(void)initialize`.

## Steps

- For each subclass of `TSDKCollectionObject` (each call of `+initialize`)
- Enumerate all _properties_ (not methods)
- Get attributes of each property (https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtPropertyIntrospection.html#//apple_ref/doc/uid/TP40008048-CH101-SW5)
- Filter out non-dynamic properties (attribute `D`)
- Assign method implementation for getters using original code from `resolveInstanceMethod:`
- Determine if property is readonly (attribute (`R`), generate default setter selector using standard form if not
- Use same method as above for getter using new selector for setter and original property
- Profit?

## Other Notes
- How bad of an idea is this? All tests pass, nothing crashes — I can't yet find anything wrong with it.
- Do we have any non-property selectors we need to synthesize that I missed?
- Yes, the logs should be deleted before merging — but they're much nicer for validation of what's going on.
- Yes, this needs to be cleaned up (var names, etc)