### PR TITLE
Preliminary concurrency support for TSDKCollectionObject

### DIFF
--- a/TeamSnapSDK.xcodeproj/xcshareddata/xcschemes/TeamSnapSDK.xcscheme
+++ b/TeamSnapSDK.xcodeproj/xcshareddata/xcschemes/TeamSnapSDK.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference

--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.h
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.h
@@ -27,14 +27,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface TSDKCollectionObject : NSObject <NSCoding, NSCopying, TSDKPersistenceFilePath>
 
-@property (nonatomic, strong, nullable) TSDKCollectionJSON * collection;
-@property (nonatomic, strong, nullable) NSMutableDictionary * changedValues;
+@property (nonatomic, copy, nullable) TSDKCollectionJSON * collection;
+@property (nonatomic, copy, readonly, nullable) NSDictionary * changedValues;
 @property (nonatomic, assign) BOOL logHeader;
 @property (nonatomic, strong, nullable) NSDate * lastUpdate;
 @property (nonatomic, strong) NSURL * persistenceBaseFilePath;
 
+- (TSDKCollectionJSON *)collection __deprecated;
+
 - (instancetype)initWithCollection:(TSDKCollectionJSON *)collection;
 + (id _Nullable)objectWithObject:(TSDKCollectionObject *)originalObject;
+
 + (void)dumpClassSelectorInfo;
 +(NSDictionary *_Nullable)template;
 +(NSDictionary *_Nullable)templateForClass:(NSString *)className;
@@ -76,6 +79,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setArray:(NSArray <NSString *> *_Nullable)value forKey:(NSString *)aKey;
 - (NSArray <NSString *> *_Nullable)getArrayForKey:(NSString *)key;
+
+- (id)collectionObjectForKey:(NSString *)key;
+- (void)removeCollectionObjectForKey:(NSString *)aKey;
+
+- (id _Nullable)changedValueForKey:(NSString *)aKey;
+- (void)setChangeValue:(id)value forKey:(NSString *)aKey;
+- (void)clearChanges;
 
 - (NSURL *_Nullable)getLink:(NSString *)aKey;
 - (void)encodeWithCoder:(NSCoder *)coder;

--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.h
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.h
@@ -33,8 +33,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) NSDate * lastUpdate;
 @property (nonatomic, strong) NSURL * persistenceBaseFilePath;
 
-- (TSDKCollectionJSON *)collection __deprecated;
-
 - (instancetype)initWithCollection:(TSDKCollectionJSON *)collection;
 + (id _Nullable)objectWithObject:(TSDKCollectionObject *)originalObject;
 
@@ -83,8 +81,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (id)collectionObjectForKey:(NSString *)key;
 - (void)removeCollectionObjectForKey:(NSString *)aKey;
 
+- (TSDKCollectionCommand *_Nullable)commandForKey:(NSString *)key;
+- (NSURL *_Nullable)linkForKey:(NSString *)key;
+
 - (id _Nullable)changedValueForKey:(NSString *)aKey;
-- (void)setChangeValue:(id)value forKey:(NSString *)aKey;
+- (void)setChangedValue:(id _Nullable)value forKey:(NSString *)aKey;
+- (void)removeChangedValueForKey:(NSString *)key;
 - (void)clearChanges;
 
 - (NSURL *_Nullable)getLink:(NSString *)aKey;

--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.m
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.m
@@ -192,6 +192,7 @@ static NSMutableDictionary *_classURLs;
         _logHeader = NO;
         _lastUpdate = nil;
         _collection_access_queue = dispatch_queue_create("com.teamsnap.sdk.collection", DISPATCH_QUEUE_CONCURRENT);
+        dispatch_set_target_queue(_collection_access_queue, dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0));
     }
     return self;
 }

--- a/TeamSnapSDK/SDK/DataTypes/Lineups/TSDKEventLineup.m
+++ b/TeamSnapSDK/SDK/DataTypes/Lineups/TSDKEventLineup.m
@@ -29,7 +29,7 @@
         
         for (NSString *key in @[@"member_id", @"sequence", @"label"]) {
             
-            NSString *value = [lineupEntry collectionObjectForKey:key];
+            NSString *value = [lineupEntry getString:key];
             if (value == nil) {
                 value = @"";
             }

--- a/TeamSnapSDK/SDK/DataTypes/Lineups/TSDKEventLineup.m
+++ b/TeamSnapSDK/SDK/DataTypes/Lineups/TSDKEventLineup.m
@@ -28,7 +28,8 @@
         NSMutableArray *lineupProperties = [NSMutableArray array];
         
         for (NSString *key in @[@"member_id", @"sequence", @"label"]) {
-            NSString *value = [lineupEntry.collection.data valueForKey:key];
+            
+            NSString *value = [lineupEntry collectionObjectForKey:key];
             if (value == nil) {
                 value = @"";
             }

--- a/TeamSnapSDK/SDK/DataTypes/Members/TSDKContact.m
+++ b/TeamSnapSDK/SDK/DataTypes/Members/TSDKContact.m
@@ -23,8 +23,8 @@
 }
 
 - (BOOL)isEditable {
-    if ([self.collection.data objectForKey:@"is_editable"]) {
-        NSNumber *value = [self.collection.data objectForKey:@"is_editable"];
+    NSNumber *value = [self collectionObjectForKey:@"is_editable"];
+    if (value != nil) {
         return [value boolValue];
     } else {
         return YES;

--- a/TeamSnapSDK/SDK/DataTypes/Members/TSDKMemberEmailAddress.m
+++ b/TeamSnapSDK/SDK/DataTypes/Members/TSDKMemberEmailAddress.m
@@ -55,7 +55,7 @@
         if ([[self class] classURL]) {
             URL = [[self class] classURL];
         } else {
-            URL = [NSURL URLWithString:[[[[[TSDKTeamSnap sharedInstance] rootLinks] collection] links] objectForKey:[[self class] SDKREL]]];
+            URL = [[[TSDKTeamSnap sharedInstance] rootLinks] linkForKey:[[self class] SDKREL]];
         }
         [self saveWithURL:URL completion:completion];
     } else {

--- a/TeamSnapSDK/SDK/DataTypes/TSDKEvent.m
+++ b/TeamSnapSDK/SDK/DataTypes/TSDKEvent.m
@@ -84,7 +84,7 @@ NSString * const kRepeatingTypeCode = @"repeating_type_code";
     
     // Until we have better support for Repeating events make sure repeating_include is set to "none"
     if (self.repeatingUuid && ([self getString:@"repeating_include"] == nil)) {
-        [self setChangeValue:self.repeatingUuid forKey:@"repeating_uuid"];
+        [self setChangedValue:self.repeatingUuid forKey:@"repeating_uuid"];
         [self setString:@"none" forKey:@"repeating_include"];
     }
     [super saveWithCompletion:completion];
@@ -97,7 +97,7 @@ NSString * const kRepeatingTypeCode = @"repeating_type_code";
 - (void)deleteAndShouldNotifyTeamAsRosterMember:(TSDKMember *)member completion:(TSDKSimpleCompletionBlock)completion {
     [self setNotifyTeamAsMember:member];
     if (self.repeatingUuid && ([self getString:@"repeating_include"] == nil)) {
-        [self setChangeValue:self.repeatingUuid forKey:@"repeating_uuid"];
+        [self setChangedValue:self.repeatingUuid forKey:@"repeating_uuid"];
         [self setString:@"none" forKey:@"repeating_include"];
     }
     [super deleteWithCompletion:completion];

--- a/TeamSnapSDK/SDK/DataTypes/TSDKEvent.m
+++ b/TeamSnapSDK/SDK/DataTypes/TSDKEvent.m
@@ -32,8 +32,8 @@ NSString * const kRepeatingTypeCode = @"repeating_type_code";
         TSDKCollectionCommand *commandToSend = [command copy];
         
         for (NSString *key in command.data) {
-            if ([event.collection.data objectForKey:key]) {
-                [commandToSend.data setObject:[event.collection.data objectForKey:key] forKey:key];
+            if ([event collectionObjectForKey:key]) {
+                [commandToSend.data setObject:[event collectionObjectForKey:key] forKey:key];
             } else {
                 [commandToSend.data setObject:[NSNull null] forKey:key];
             }
@@ -69,7 +69,7 @@ NSString * const kRepeatingTypeCode = @"repeating_type_code";
         [self setBool:YES forKey:@"notify_team"];
         [self setString:member.objectIdentifier forKey:@"notify_team_as_member_id"];
     } else {
-        [self.collection.data removeObjectForKey:@"notify_team_as_member_id"];
+        [self removeCollectionObjectForKey:@"notify_team_as_member_id"];
         [self setBool:NO forKey:@"notify_team"];
     }
 }
@@ -84,7 +84,7 @@ NSString * const kRepeatingTypeCode = @"repeating_type_code";
     
     // Until we have better support for Repeating events make sure repeating_include is set to "none"
     if (self.repeatingUuid && ([self getString:@"repeating_include"] == nil)) {
-        [self.changedValues setObject:self.repeatingUuid forKey:@"repeating_uuid"];
+        [self setChangeValue:self.repeatingUuid forKey:@"repeating_uuid"];
         [self setString:@"none" forKey:@"repeating_include"];
     }
     [super saveWithCompletion:completion];
@@ -97,7 +97,7 @@ NSString * const kRepeatingTypeCode = @"repeating_type_code";
 - (void)deleteAndShouldNotifyTeamAsRosterMember:(TSDKMember *)member completion:(TSDKSimpleCompletionBlock)completion {
     [self setNotifyTeamAsMember:member];
     if (self.repeatingUuid && ([self getString:@"repeating_include"] == nil)) {
-        [self.changedValues setObject:self.repeatingUuid forKey:@"repeating_uuid"];
+        [self setChangeValue:self.repeatingUuid forKey:@"repeating_uuid"];
         [self setString:@"none" forKey:@"repeating_include"];
     }
     [super deleteWithCompletion:completion];
@@ -165,7 +165,7 @@ NSString * const kRepeatingTypeCode = @"repeating_type_code";
 }
 
 - (TSDKRepeatingEventTypeCode)repeatingTypeCode {
-    if ([[self.collection data] objectForKey:kRepeatingTypeCode]) {
+    if ([self collectionObjectForKey:kRepeatingTypeCode]) {
         return [self getInteger:kRepeatingTypeCode];
     } else {
         return TSDKEventDoesNotRepeat;
@@ -174,7 +174,7 @@ NSString * const kRepeatingTypeCode = @"repeating_type_code";
 
 - (void)setRepeatingTypeCode:(TSDKRepeatingEventTypeCode)repeatingTypeCode {
     if (repeatingTypeCode == 0) {
-        [[[self collection] data] removeObjectForKey:kRepeatingTypeCode];
+        [self removeCollectionObjectForKey:kRepeatingTypeCode];
     } else {
         [self setInteger:repeatingTypeCode forKey:kRepeatingTypeCode];
     }

--- a/TeamSnapSDK/SDK/DataTypes/TSDKRootLinks.m
+++ b/TeamSnapSDK/SDK/DataTypes/TSDKRootLinks.m
@@ -140,7 +140,7 @@
 + (void)actionSendInvitationsToEmailaddress:(NSString *)emailAddress WithCompletion:(TSDKCompletionBlock)completion {
     [[TSDKTeamSnap sharedInstance] rootLinksWithConfiguration:nil completion:^(TSDKRootLinks *rootLinks, NSError * _Nullable error) {
         if (rootLinks) {
-            TSDKCollectionCommand *collectionCommand = [rootLinks.collection.commands objectForKey:@"send_invitations"];
+            TSDKCollectionCommand *collectionCommand = [rootLinks commandForKey:@"send_invitations"];
             if (collectionCommand) {
                 [collectionCommand.data setObject:emailAddress forKey:@"email_address"];
                 [collectionCommand executeWithCompletion:completion];

--- a/TeamSnapSDK/SDK/DataTypes/TSDKTeam.m
+++ b/TeamSnapSDK/SDK/DataTypes/TSDKTeam.m
@@ -193,8 +193,8 @@
 
 - (void)setTimeZoneIanaName:(NSString *)timeZoneIanaName {
     [self setString:timeZoneIanaName forKey:@"time_zone_iana_name"];
-    self.collection.data[@"time_zone"] = timeZoneIanaName;
-    [self.changedValues setObject:[NSNull null] forKey:@"time_zone"];
+    [self setString:timeZoneIanaName forKey:@"time_zone"];
+    [self setChangeValue:[NSNull null] forKey:@"time_zone"];
 }
 
 - (NSTimeZone *)timeZone {
@@ -280,13 +280,7 @@
 }
 
 - (id)copyWithZone:(nullable NSZone *)zone {
-    id copy = [[[self class] allocWithZone:zone] init];
-    
-    if (copy) {
-        [copy setCollection:[[self collection] copy]];
-    }
-    
-    return copy;
+    return [[[self class] allocWithZone:zone] initWithCollection:self.collection];
 }
 
 - (void)emailOwnerForUpsellFeature:(NSString * _Nonnull)feature fromContactId:(NSString * _Nonnull)contactId isOwner:(BOOL)isOwner completion:(TSDKSimpleCompletionBlock _Nullable)completion {

--- a/TeamSnapSDK/SDK/DataTypes/TSDKTeam.m
+++ b/TeamSnapSDK/SDK/DataTypes/TSDKTeam.m
@@ -194,7 +194,7 @@
 - (void)setTimeZoneIanaName:(NSString *)timeZoneIanaName {
     [self setString:timeZoneIanaName forKey:@"time_zone_iana_name"];
     [self setString:timeZoneIanaName forKey:@"time_zone"];
-    [self setChangeValue:[NSNull null] forKey:@"time_zone"];
+    [self removeChangedValueForKey:@"time_zone"];
 }
 
 - (NSTimeZone *)timeZone {
@@ -277,10 +277,6 @@
     NSURLQueryItem *cropQueryItem = [NSURLQueryItem queryItemWithName:@"crop" value:@"proportional"];
     
     return [self.linkTeamPhotoFile URLByAppendingArrayOfQueryItems:@[widthQueryItem, heightQueryItem, cropQueryItem]];
-}
-
-- (id)copyWithZone:(nullable NSZone *)zone {
-    return [[[self class] allocWithZone:zone] initWithCollection:self.collection];
 }
 
 - (void)emailOwnerForUpsellFeature:(NSString * _Nonnull)feature fromContactId:(NSString * _Nonnull)contactId isOwner:(BOOL)isOwner completion:(TSDKSimpleCompletionBlock _Nullable)completion {

--- a/TeamSnapSDKTests/DataType/TSDKMemberTests.m
+++ b/TeamSnapSDKTests/DataType/TSDKMemberTests.m
@@ -29,10 +29,10 @@
     TSDKMember *member = [[TSDKMember alloc] init];
     XCTAssertEqualObjects(@"", member.fullName);
     
-    [member.collection.data setValue:[NSNull null] forKey:@"first_name"];
+    [member removeCollectionObjectForKey:@"first_name"];
     XCTAssertEqualObjects(@"", member.fullName);
     
-    [member.collection.data setValue:[NSNull null] forKey:@"last_name"];
+    [member removeCollectionObjectForKey:@"last_name"];
     XCTAssertEqualObjects(@"", member.fullName);
     
     member.firstName = @"Ronnie";

--- a/TeamSnapSDKTests/TSDKCollectionObjectTests.m
+++ b/TeamSnapSDKTests/TSDKCollectionObjectTests.m
@@ -140,7 +140,7 @@
     NSString *testValue = @"test event";
     event.name = testValue;
     XCTAssertEqual(event.name, testValue);
-    XCTAssertEqual([event.changedValues objectForKey:@"name"], [NSNull null]);
+    XCTAssertNil([event.changedValues objectForKey:@"name"]);
     [event clearChanges];
     
     event.name = testValue;

--- a/TeamSnapSDKTests/TSDKCollectionObjectTests.m
+++ b/TeamSnapSDKTests/TSDKCollectionObjectTests.m
@@ -62,7 +62,7 @@
     [paymentNoPayment undoChanges];
     XCTAssertEqualObjects(paymentNoPayment.teamId, @"949008");
 
-    [paymentNoPayment.collection.data removeObjectForKey:@"team_id"];
+    [paymentNoPayment removeCollectionObjectForKey:@"team_id"];
     XCTAssertNotEqualObjects(paymentNoPayment.teamId, @"");
     XCTAssertNil(paymentNoPayment.teamId);
     
@@ -88,7 +88,7 @@
         TSDKUser *newUser = [TSDKUser objectWithObject:user];
         XCTAssertNotNil(newUser);
         XCTAssertTrue(newUser.isNewObject);
-        XCTAssertNil([newUser.collection.data objectForKey:@"team_id"]);
+        XCTAssertNil([newUser collectionObjectForKey:@"team_id"]);
         XCTAssertEqualObjects(newUser.lastName, @"Joe");
         NSString *objectClassName = NSStringFromClass([newUser class]);
         XCTAssertEqualObjects(objectClassName, @"TSDKUser");
@@ -107,7 +107,7 @@
         XCTAssertEqualObjects(user.firstName, @"First");
         XCTAssertEqualObjects([[user changedValues] valueForKey:@"first_name"] , @"Tester");
         user.lastName = nil;
-        XCTAssertEqualObjects([[user.collection data] valueForKey:@"last_name"], [NSNull null]);
+        XCTAssertEqualObjects([user collectionObjectForKey:@"last_name"], [NSNull null]);
         XCTAssertNil(user.lastName);
         XCTAssertEqualObjects([[user changedValues] valueForKey:@"last_name"], @"Joe");
         
@@ -141,7 +141,7 @@
     event.name = testValue;
     XCTAssertEqual(event.name, testValue);
     XCTAssertEqual([event.changedValues objectForKey:@"name"], [NSNull null]);
-    [event.changedValues removeAllObjects];
+    [event clearChanges];
     
     event.name = testValue;
     XCTAssertEqual(event.name, testValue);
@@ -198,11 +198,11 @@
         TSDKCollectionJSON *subCollection = [(NSArray *)_userCollectionJSON.collection firstObject];
         
         TSDKUser *user= [[TSDKUser alloc] initWithCollection:subCollection];
-        [user.collection.data setObject:@"" forKey:@"created_at"];
+        [user setString:@"" forKey:@"created_at"];
         XCTAssertNoThrow(user.createdAt);
     }
     
-    [[event.collection data] setObject:@"8-13" forKey:@"start_date"];
+    [event setString:@"8-13" forKey:@"start_date"];
     XCTAssertNoThrow(event.startDate);
 }
 


### PR DESCRIPTION
This adds a basic locking queue for the underling `TSDKCollectionJSON` `collection` property on `TSDKCollectionObject`.

## Some notable changes
- `TSDKCollectionJSON * collection` moved from a strong property to a copy property, internally locked copy-on-read
- `NSMutableDictionary * changedValues` moved from a strong property to a `copy` `NSDictionary * changedValues` property, internally locked copy-on-read
- All changes to `TSDKCollectionObject`'s underlying state should now be locked internally — writes are async, and reads are synchronous

## Questions
- Given the large number of objects, will this spawn tons of unnecessary threads despite explicitly setting the target queue for our locking queue to a global concurrent queue?
- This impacts the public interface, specifically the by-reference nature of collection access and modification by consumers. This isn't really a question, more of a callout of the impace.
