### PR TITLE
Revert name of assignMethodImplementationForSelector back to resolveInstanceMethod so it gets called when a property/method isn't found

### DIFF
--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.m
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.m
@@ -32,7 +32,6 @@ static NSMutableDictionary *_queryDictionary;
 static NSMutableDictionary *_classURLs;
 
 + (void)initialize {
-    [super initialize];
     // Explicitly not checking for subclasses here in order to synthesize dynamic property
     //  method implementations for ALL subclasses of TSDKCollectionObject
     [self synthesizePropertyImplementations];

--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.m
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.m
@@ -31,8 +31,8 @@ static NSMutableDictionary *_commandDictionary;
 static NSMutableDictionary *_queryDictionary;
 static NSMutableDictionary *_classURLs;
 
-+ (void)initialize
-{
++ (void)initialize {
+    [super initialize];
     // Explicitly not checking for subclasses here in order to synthesize dynamic property
     //  method implementations for ALL subclasses of TSDKCollectionObject
     [self synthesizePropertyImplementations];
@@ -463,7 +463,7 @@ static BOOL property_getTypeString( objc_property_t property, char *buffer ) {
 
 static void addImplementationForSelector(objc_property_t prop, SEL selector, Class class) {
     if (selector != NULL) {
-        if ([class assignMethodImplementationForSelector:selector]) {
+        if ([class resolveInstanceMethod:selector]) {
             RuntimeLog(@"✅ Successfully added custom implementation for property %@", NSStringFromSelector(selector));
         } else {
             RuntimeLog(@"❌ Failed to add custom implementation for property %@", NSStringFromSelector(selector));
@@ -543,7 +543,7 @@ static void addImplementationForSelector(objc_property_t prop, SEL selector, Cla
     }
 }
 
-+ (BOOL)assignMethodImplementationForSelector:(SEL)aSEL {
++ (BOOL)resolveInstanceMethod:(SEL)aSEL {
     //NSString *command = [NSStringFromSelector(aSEL) camelCaseToUnderscores];
     
     NSMutableString *property = [NSMutableString stringWithString:NSStringFromSelector(aSEL)];

--- a/TeamSnapSDKTests/TSDKCollectionObjectTests.m
+++ b/TeamSnapSDKTests/TSDKCollectionObjectTests.m
@@ -283,4 +283,14 @@
     XCTAssertTrue(event.gameTypeCode == TSDKGameTypeCodeUnknown, @"Event Game type code should have parsed as unknown");
 }
 
+- (void)testDynamicMethod {
+    TSDKCollectionJSON *memberPaymentsCollection = [TSDKJSONFileResource collectionFromJSONFileNamed:@"MemberPayments"];
+    NSArray *memberPayments = memberPaymentsCollection.collection;
+    TSDKMemberPayment *memberPayment = [[TSDKMemberPayment alloc] initWithCollection: [memberPayments firstObject]];
+    
+    [memberPayment getMemberWithConfiguration:nil completion:^(BOOL success, BOOL complete, NSArray<TSDKMember *> * _Nullable members, NSError * _Nullable error) {
+        // We don't care if this returns. We just want to make sure the getMemberWithConfiguration didn't fail.
+    }];
+}
+
 @end


### PR DESCRIPTION
Issue: 

When either dynamic properties or methods are called the first time, and not found the Objc runtime calls `resolveInstanceMethod`. And although all the properties were getting synthesized properly the dynamic methods were not and `resolveInstanceMethod` wasn't there to define them. 

Testing: 

Create a roster member. it calls `[member getContactsWithConfiguration:]` and crashes.

also. +initialize wasn't calling super.