### PR TITLE
Add Launch Argument for cURL Output

### DIFF
--- a/TeamSnapSDK/SDK/DataLayer/TSDKDataRequest.m
+++ b/TeamSnapSDK/SDK/DataLayer/TSDKDataRequest.m
@@ -183,10 +183,10 @@ static NSRecursiveLock *accessDetailsLock = nil;
             [request setHTTPBody:data];
             [request setValue:@"application/json; charset=utf-8" forHTTPHeaderField:@"Content-Type"];
         }
-                
-#ifdef DEBUGCURL
-        DLog(@"Curl:\n%@", [request getCurlEquivalent]);
-#endif
+
+        if ([[[NSProcessInfo processInfo] arguments] containsObject:@"-tsdk_request_curl"]) {
+            DLog(@"Curl:\n%@", [request getCurlEquivalent]);
+        }
         
         if([[TSDKDuplicateCompletionBlockStore sharedInstance] existingRequestExistsMatchingRequest:request]) {
             [[TSDKDuplicateCompletionBlockStore sharedInstance] addCompletionBlock:completionBlock forRequest:request];
@@ -461,9 +461,10 @@ static NSRecursiveLock *accessDetailsLock = nil;
     
     [request setHTTPMethod:@"GET"];
     [request setCachePolicy:NSURLRequestReturnCacheDataElseLoad];
-#ifdef DEBUGCURL
-    DLog(@"Curl:\n%@", [request getCurlEquivalent]);
-#endif
+
+    if ([[[NSProcessInfo processInfo] arguments] containsObject:@"-tsdk_request_curl"]) {
+        DLog(@"Curl:\n%@", [request getCurlEquivalent]);
+    }
     
 #if TARGET_OS_IPHONE
     [[TSDKNetworkActivityIndicator sharedInstance] startActivity];


### PR DESCRIPTION
This converts our compile-time flag into a launch argument flag for cURL SDK request output. The previous method of defining `DEBUGCURL` as a build-time macro argument required recompilation and modification of the SDK in order to print cURL requests. With this method, a simple scheme modification will print cURL-formatted requests being transmitted through the SDK without requiring a recompile.

<img src="https://user-images.githubusercontent.com/590216/108762682-405c2900-7505-11eb-8071-70385d354353.png" />
