### PR TITLE
NSKeyedArchiver iOS 13 Deprecations

### DIFF
--- a/TeamSnapSDK/SDK/Cache/TSPCache.m
+++ b/TeamSnapSDK/SDK/Cache/TSPCache.m
@@ -189,7 +189,7 @@ NSFileManager static *_fileManager = nil;
         
         NSData *schemaData;
 
-        if (@available(iOS 12, *)) {
+        if (@available(iOS 11, *)) {
             schemaData = [NSKeyedArchiver archivedDataWithRootObject:schemaArray requiringSecureCoding:NO error:&error];
         } else {
 #pragma clang diagnostic push
@@ -228,7 +228,7 @@ NSFileManager static *_fileManager = nil;
         if (cachedVersion && [cachedVersion isEqualToString:schemaVersion]) {
             NSData *schemaData = [NSData dataWithContentsOfURL:fileURL];
             
-            if (@available(iOS 12, *)) {
+            if (@available(iOS 11, *)) {
                 NSSet<Class> *validClasses = [NSSet setWithObjects: [NSDictionary class], [NSArray class], [NSString class], [NSNumber class], [NSNull class], nil];
                 id obj = [NSKeyedUnarchiver unarchivedObjectOfClasses:validClasses
                                                            fromData:schemaData

--- a/TeamSnapSDK/SDK/Cache/TSPCache.m
+++ b/TeamSnapSDK/SDK/Cache/TSPCache.m
@@ -230,14 +230,14 @@ NSFileManager static *_fileManager = nil;
             
             if (@available(iOS 11, *)) {
                 NSSet<Class> *validClasses = [NSSet setWithObjects: [NSDictionary class], [NSArray class], [NSString class], [NSNumber class], [NSNull class], nil];
-                id obj = [NSKeyedUnarchiver unarchivedObjectOfClasses:validClasses
+                NSArray* rootSchemaList = [NSKeyedUnarchiver unarchivedObjectOfClasses:validClasses
                                                            fromData:schemaData
                                                               error:&error];
 
                 if (error != nil) {
-                    NSLog(@"Error: %@", error);
+                    NSLog(@"Error unarchiving saved data for root schemas: %@", error);
                 }
-                return obj;
+                return rootSchemaList;
             } else {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -246,7 +246,16 @@ NSFileManager static *_fileManager = nil;
             }
         } else {
             [[self fileManager] removeItemAtURL:versionFileURL error:&error];
+
+            if (error != nil) {
+                NSLog(@"Error removing old data for version file URLs: %@", error);
+            }
+
             [[self fileManager] removeItemAtURL:fileURL error:&error];
+
+            if (error != nil) {
+                NSLog(@"Error removing old data for root schemas: %@", error);
+            }
         }
         return nil;
     } else {

--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionJSON.m
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionJSON.m
@@ -83,13 +83,29 @@
 }
 
 - (NSData *)dataEncodedForSave {
-    NSData *saveData = [NSKeyedArchiver archivedDataWithRootObject:self];
-    return saveData;
+    if (@available(iOS 11, *)) {
+        return [NSKeyedArchiver archivedDataWithRootObject:self
+                                     requiringSecureCoding:NO
+                                                     error:nil];
+    } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        return [NSKeyedArchiver archivedDataWithRootObject:self];
+#pragma clang diagnostic pop
+    }
 }
 
 + (instancetype)collectionJSONForEncodedData:(NSData *)objectData {
-    id anObject = [NSKeyedUnarchiver unarchiveObjectWithData:objectData];
-    return anObject;
+    if (@available(iOS 11, *)) {
+        return [NSKeyedUnarchiver unarchivedObjectOfClass:[TSDKCollectionJSON class]
+                                                 fromData:objectData
+                                                    error:nil];
+    } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        return [NSKeyedUnarchiver unarchiveObjectWithData:objectData];
+#pragma clang diagnostic pop
+    }
 }
 
 -(void)parseJSON:(NSDictionary *)collection {

--- a/TeamSnapSDK/SDK/DataLayer/TSDKDataRequest.m
+++ b/TeamSnapSDK/SDK/DataLayer/TSDKDataRequest.m
@@ -194,11 +194,25 @@ static NSRecursiveLock *accessDetailsLock = nil;
             [[TSDKDuplicateCompletionBlockStore sharedInstance] addCompletionBlock:completionBlock forRequest:request];
             
 #if TARGET_OS_IPHONE
-            [[TSDKNetworkActivityIndicator sharedInstance] startActivity];
+            if (@available(iOS 13, *)) {
+
+            } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                [[TSDKNetworkActivityIndicator sharedInstance] startActivity];
+#pragma clang diagnostic pop
+            }
 #endif
             NSURLSessionDataTask *remoteTask = [[TSDKDataRequest session] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
 #if TARGET_OS_IPHONE
-                [[TSDKNetworkActivityIndicator sharedInstance] stopActivity];
+                if (@available(iOS 13, *)) {
+                    
+                } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                    [[TSDKNetworkActivityIndicator sharedInstance] stopActivity];
+#pragma clang diagnostic pop
+                }
 #endif
                 
                 dispatch_async([self processingQueue], ^{
@@ -466,11 +480,25 @@ static NSRecursiveLock *accessDetailsLock = nil;
 #endif
     
 #if TARGET_OS_IPHONE
+    if (@available(iOS 13, *)) {
+
+    } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [[TSDKNetworkActivityIndicator sharedInstance] startActivity];
+#pragma clang diagnostic pop
+    }
 #endif
     NSURLSessionDataTask *remoteTask = [[TSDKDataRequest session] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
 #if TARGET_OS_IPHONE
-        [[TSDKNetworkActivityIndicator sharedInstance] stopActivity];
+        if (@available(iOS 13, *)) {
+
+        } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+            [[TSDKNetworkActivityIndicator sharedInstance] stopActivity];
+#pragma clang diagnostic pop
+        }
 #endif
         
         dispatch_async([self processingQueue], ^{

--- a/TeamSnapSDK/SDK/DataLayer/TSDKNetworkActivityIndicator.h
+++ b/TeamSnapSDK/SDK/DataLayer/TSDKNetworkActivityIndicator.h
@@ -8,6 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
+NS_CLASS_DEPRECATED_IOS(3_0, 13_0, "Functionality removed in iOS 13+")
 @interface TSDKNetworkActivityIndicator : NSObject
 
 + (instancetype _Nonnull)sharedInstance;

--- a/TeamSnapSDK/SDK/DataLayer/TSDKNetworkActivityIndicator.m
+++ b/TeamSnapSDK/SDK/DataLayer/TSDKNetworkActivityIndicator.m
@@ -14,7 +14,10 @@
 
 @end
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation TSDKNetworkActivityIndicator
+#pragma clang diagnostic pop
 
 + (instancetype)sharedInstance {
     static dispatch_once_t onceToken;
@@ -44,6 +47,7 @@
     }
     [self setActivityIndicatorVisible:showIndicator];
 }
+
 
 - (void)setActivityIndicatorVisible:(BOOL)visible {
     Class UIApplicationClass = NSClassFromString(@"UIApplication");


### PR DESCRIPTION
iOS 13 hard-deprecated some NSKeyedArchiver/NSKeyedUnarchiver functions that were introduced in iOS 11. This results in warnings that display when your deployment target is set >= 13.0.

This converts those APIs to use the new methods when the device allows while still implementing the old methods for other devices.