### PR TITLE
NSCoding -> NSSecureCoding

### DIFF
--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionCommand.h
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionCommand.h
@@ -8,7 +8,7 @@
 
 #import "TSDKCollectionQuery.h"
 
-@interface TSDKCollectionCommand : TSDKCollectionQuery <NSCopying, NSCoding>
+@interface TSDKCollectionCommand : TSDKCollectionQuery <NSCopying, NSSecureCoding>
 
 -(void)executeCollectionJSONTemplateWithCompletion:(TSDKCompletionBlock _Nullable)completion;
 

--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionCommand.m
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionCommand.m
@@ -13,6 +13,10 @@
 
 @implementation TSDKCollectionCommand
 
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
 -(void)executeWithCompletion:(TSDKCompletionBlock)completion {
     NSURL *destinationURL = [NSURL URLWithString:self.href];
     

--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionJSON.h
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionJSON.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface TSDKCollectionJSON : NSObject <NSCoding, NSCopying>
+@interface TSDKCollectionJSON : NSObject <NSSecureCoding, NSCopying>
 
 @property (nonatomic, strong) NSURL *_Nullable href;
 @property (nonatomic, strong) NSString *_Nullable version;

--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionJSON.m
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionJSON.m
@@ -82,10 +82,14 @@
     
 }
 
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
 - (NSData *)dataEncodedForSave {
     if (@available(iOS 11, *)) {
         return [NSKeyedArchiver archivedDataWithRootObject:self
-                                     requiringSecureCoding:NO
+                                     requiringSecureCoding:YES
                                                      error:nil];
     } else {
 #pragma clang diagnostic push

--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionJSON.m
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionJSON.m
@@ -41,15 +41,31 @@
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
     self = [self init];
     if (self) {
-        _href = [aDecoder decodeObjectForKey:@"href"];
-        _rel = [aDecoder decodeObjectForKey:@"rel"];
-        _type = [aDecoder decodeObjectForKey:@"type"];
-        _version = [aDecoder decodeObjectForKey:@"version"];
-        _links = [aDecoder decodeObjectForKey:@"links"];
-        _data = [aDecoder decodeObjectForKey:@"data"];
-        _collection = [aDecoder decodeObjectForKey:@"collection"];
-        _commands = [aDecoder decodeObjectForKey:@"commands"];
-        _queries = [aDecoder decodeObjectForKey:@"queries"];
+        _href = [aDecoder decodeObjectOfClass:[NSURL class] forKey:@"href"];
+        _rel = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"rel"];
+        _type = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"type"];
+        _version = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"version"];
+        _links = [aDecoder decodeObjectOfClass:[NSDictionary class] forKey:@"links"];
+
+        NSSet *validDataClasses = [NSSet setWithArray:@[
+            [NSMutableDictionary class],
+            [NSArray class],
+            [NSNull class],
+        ]];
+        _data = [aDecoder decodeObjectOfClasses:validDataClasses forKey:@"data"];
+        NSSet *validCollectionJSONClasses = [NSSet setWithArray:@[
+            [TSDKCollectionJSON class],
+            [NSURL class],
+            [NSString class],
+            [NSDictionary class],
+            [NSMutableArray class],
+            [NSMutableDictionary class],
+            [NSNull class],
+        ]];
+        _collection = [aDecoder decodeObjectOfClasses:validCollectionJSONClasses
+                                               forKey:@"collection"];
+        _commands = [aDecoder decodeObjectOfClass:[NSDictionary class] forKey:@"commands"];
+        _queries = [aDecoder decodeObjectOfClass:[NSDictionary class] forKey:@"queries"];
     }
     return self;
 }

--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.h
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface TSDKCollectionObject : NSObject <NSCoding, NSCopying, TSDKPersistenceFilePath>
+@interface TSDKCollectionObject : NSObject <NSSecureCoding, NSCopying, TSDKPersistenceFilePath>
 
 @property (nonatomic, copy, readonly, nullable) TSDKCollectionJSON * collection __deprecated;
 @property (nonatomic, copy, readonly, nullable) NSDictionary * changedValues;
@@ -79,7 +79,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setArray:(NSArray <NSString *> *_Nullable)value forKey:(NSString *)aKey;
 - (NSArray <NSString *> *_Nullable)getArrayForKey:(NSString *)key;
 
-- (void)setCollectionObject:(NSObject<NSCoding> * _Nullable)object forKey:(NSString *)key;
+- (void)setCollectionObject:(NSObject<NSSecureCoding> * _Nullable)object forKey:(NSString *)key;
 - (id)collectionObjectForKey:(NSString *)key;
 - (void)removeCollectionObjectForKey:(NSString *)aKey;
 - (void)setCollectionHref:(NSURL *)href;

--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.m
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.m
@@ -265,10 +265,20 @@ static NSMutableDictionary *_classURLs;
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
-    TSDKCollectionJSON *collection = [aDecoder decodeObjectForKey:@"collection"];
+    NSSet *validCollectionJSONClasses = [NSSet setWithArray:@[
+        [TSDKCollectionJSON class],
+        [NSURL class],
+        [NSString class],
+        [NSDictionary class],
+        [NSMutableArray class],
+        [NSMutableDictionary class],
+        [NSNull class],
+    ]];
+    TSDKCollectionJSON *collection = [aDecoder decodeObjectOfClasses:validCollectionJSONClasses
+                                                            forKey:@"collection"];
     // we currently only persist collection data and the last update date.
     self = [self initWithCollection:collection];
-    self.lastUpdate = [aDecoder decodeObjectForKey:@"lastUpdate"];
+    self.lastUpdate = [aDecoder decodeObjectOfClass:[NSDate class] forKey:@"lastUpdate"];
     return self;
 }
 

--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.m
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.m
@@ -48,6 +48,10 @@ static NSMutableDictionary *_classURLs;
     }
 }
 
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
 - (NSMutableDictionary *)cachedDatesLookup {
     if (!_cachedDatesLookup) {
         _cachedDatesLookup = [[NSMutableDictionary alloc] init];
@@ -665,7 +669,7 @@ static void addImplementationForSelector(objc_property_t prop, SEL selector, Cla
     [self setObject:value forKey:key];
 }
 
-- (void)setObject:(NSObject<NSCoding> *)value forKey:(NSString *)aKey {
+- (void)setObject:(NSObject<NSSecureCoding> *)value forKey:(NSString *)aKey {
     
     id __block collectionData = nil;
     dispatch_sync(self.collection_access_queue, ^{
@@ -795,7 +799,7 @@ static void addImplementationForSelector(objc_property_t prop, SEL selector, Cla
     return data;
 }
 
-- (void)setCollectionObject:(NSObject<NSCoding> * _Nullable)object forKey:(NSString *)key {
+- (void)setCollectionObject:(NSObject<NSSecureCoding> * _Nullable)object forKey:(NSString *)key {
     [self setObject:object forKey:key];
 }
 

--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionQuery.h
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionQuery.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "TSDKCompletionBlockTypes.h"
 
-@interface TSDKCollectionQuery : NSObject <NSCopying, NSCoding>
+@interface TSDKCollectionQuery : NSObject <NSCopying, NSSecureCoding>
 
 @property (nonatomic, strong) NSMutableDictionary *_Nullable data;
 @property (nonatomic, strong) NSString *_Nullable href;

--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionQuery.m
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionQuery.m
@@ -50,6 +50,10 @@
     return self;
 }
 
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
 -(void)executeWithCompletion:(TSDKCompletionBlock)completion {
     NSURL *destinationURL = [NSURL URLWithString:self.href];
     

--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionQuery.m
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionQuery.m
@@ -42,10 +42,10 @@
 -(instancetype)initWithCoder:(NSCoder *)aDecoder {
     self = [self init];
     if (self) {
-        _data = [aDecoder decodeObjectForKey:@"data"];
-        _href = [aDecoder decodeObjectForKey:@"href"];
-        _rel = [aDecoder decodeObjectForKey:@"rel"];
-        _prompt = [aDecoder decodeObjectForKey:@"prompt"];
+        _data = [aDecoder decodeObjectOfClass:[NSMutableDictionary class] forKey:@"data"];
+        _href = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"href"];
+        _rel = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"rel"];
+        _prompt = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"prompt"];
     }
     return self;
 }

--- a/TeamSnapSDK/SDK/DataLayer/TSDKDataRequest.m
+++ b/TeamSnapSDK/SDK/DataLayer/TSDKDataRequest.m
@@ -250,6 +250,8 @@ static NSRecursiveLock *accessDetailsLock = nil;
                             NSInteger errorCode = ((NSHTTPURLResponse *)response).statusCode;
                             if (errorJSON.errorCode != NSNotFound) {
                                 errorCode = [userInfo[@"errorCode"] integerValue];
+                            } else if (userInfo[NSLocalizedDescriptionKey] == nil) {
+                                userInfo[NSLocalizedDescriptionKey] = [NSHTTPURLResponse localizedStringForStatusCode:errorCode];
                             }
                             
                             if([response isKindOfClass:[NSHTTPURLResponse class]]) {

--- a/TeamSnapSDK/SDK/Protocols/TSDKPersistenceFilePath.h
+++ b/TeamSnapSDK/SDK/Protocols/TSDKPersistenceFilePath.h
@@ -12,7 +12,7 @@
 
 
 /**
- The document directory file path where objects conforming to NSCoding will be encoded and stored.
+ The document directory file path where objects conforming to NSSecureCoding will be encoded and stored.
 
  @param parentObject The parent of the data to be stored. Team is the parent of Events, for example.
  @return A fully specified URL where objects can be encoded for persistence. Documents directory is recommended.


### PR DESCRIPTION
This opts TSDK base objects into being NSSecureCoding compatible. This is required to use the iOS11+ NSKeyedArchiver/NSKeyedUnarchiver APIs.