### PR TITLE
DSP Targeting

### DIFF
--- a/TeamSnapSDK/SDK/DataLayer/TSDKDataRequest.m
+++ b/TeamSnapSDK/SDK/DataLayer/TSDKDataRequest.m
@@ -297,10 +297,11 @@ static NSRecursiveLock *accessDetailsLock = nil;
             for (NSString *key in searchParamaters) {
                 id value = [searchParamaters objectForKey:key];
                 if([value isKindOfClass:[NSArray class]]) {
-                    NSString *commaSeparatedString = [value componentsJoinedByString:@","];
+                    NSString *commaSeparatedString = [[value componentsJoinedByString:@","] stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
                     [searchParamaterArray addObject:[NSString stringWithFormat:@"%@=%@", key, commaSeparatedString]];
                 } else  {
-                    [searchParamaterArray addObject:[NSString stringWithFormat:@"%@=%@", key, value]];
+                    NSString *encodedValue = [value stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+                    [searchParamaterArray addObject:[NSString stringWithFormat:@"%@=%@", key, encodedValue]];
                 }
                 
             }

--- a/TeamSnapSDK/SDK/DataTypes/TSDKUser.h
+++ b/TeamSnapSDK/SDK/DataTypes/TSDKUser.h
@@ -76,6 +76,16 @@ typedef NS_CLOSED_ENUM(NSInteger,TSDKHighestRoleType) {
 - (NSString *_Nonnull)fullName;
 - (NSInteger)age;
 
+/// Fetch a JSON-payload formatted for pass-through to a DSP of your choice.
+///
+/// @note This is a first-party only endpoint unavailable without a first-party app ID/secret.
+///
+/// @param memberId Member ID to fetch payload for
+/// @param kuid Unique identifier for advertising
+/// @param zone Advertising zone
+/// @param completion Completion returning advertising payload as a NSDictionary<String,String>
++(void)queryDspPayloadMemberid:(NSString *_Nonnull)memberId kuid:(NSString *_Nonnull)kuid zone:(NSString *_Nonnull)zone WithCompletion:(TSDKCompletionBlock _Nullable)completion;
+
 @end
 
 @interface TSDKUser (ForwardedMethods)

--- a/TeamSnapSDK/SDK/DataTypes/TSDKUser.m
+++ b/TeamSnapSDK/SDK/DataTypes/TSDKUser.m
@@ -76,6 +76,14 @@
     }];
 }
 
++(void)queryDspPayloadMemberid:(NSString *_Nonnull)memberId kuid:(NSString *_Nonnull)kuid zone:(NSString *_Nonnull)zone WithCompletion:(TSDKCompletionBlock _Nullable)completion {
+    TSDKCollectionQuery *query = [self queryForKey:@"dsp_payload"];
+    query.data[@"member_id"] = memberId;
+    query.data[@"zone"] = zone;
+    query.data[@"kuid"] = kuid;
+    [query executeWithCompletion:completion];
+}
+
 - (void)myMembersOnTeamsWithConfiguration:(TSDKRequestConfiguration *)configuration completion:(TSDKArrayCompletionBlock)completion {
     [self getPersonasWithConfiguration:configuration completion:completion];
 }


### PR DESCRIPTION
This adds a first-party endpoint to fetch advertising targeting data from SNAPI. This API will only work with first-party app ID/secret tokens and is intentionally left opaque in the SDK.