### PR TITLE
BAM-2566 Request Params Crash

### DIFF
--- a/TeamSnapSDK/SDK/DataLayer/TSDKDataRequest.m
+++ b/TeamSnapSDK/SDK/DataLayer/TSDKDataRequest.m
@@ -301,11 +301,12 @@ static NSRecursiveLock *accessDetailsLock = nil;
                 if([value isKindOfClass:[NSArray class]]) {
                     NSString *commaSeparatedString = [[value componentsJoinedByString:@","] stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
                     [searchParamaterArray addObject:[NSString stringWithFormat:@"%@=%@", key, commaSeparatedString]];
-                } else  {
+                } else if ([value respondsToSelector:@selector(stringByAddingPercentEncodingWithAllowedCharacters:)]) {
                     NSString *encodedValue = [value stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
                     [searchParamaterArray addObject:[NSString stringWithFormat:@"%@=%@", key, encodedValue]];
+                } else {
+                    [searchParamaterArray addObject:[NSString stringWithFormat:@"%@=%@", key, value]];
                 }
-                
             }
             NSString *separator = @"&";
             if ([URLPath rangeOfString:@"?"].location == NSNotFound) {


### PR DESCRIPTION
This is a regression caused by #312 whereby percent encoding was added to all requests. This seemed reasonable since request values were _assumed_ to all be strings. For some rare requests, the parameter values are coming in as numbers. Namely, the commissioner league email authoring endpoint uses number-params in the `page_size` and `page` params.

This will solve this issue for all requests, even if they aren't of sufficient volume to show up in our crash reports and reverts the worst-case scenario back to the original code logic while retaining the percent-encoding addition of the previous change.