### PR TITLE
GD-83: Xcode 13: Cleanup NSKeyedUnarchiver warnings 

### DIFF
--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionJSON.m
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionJSON.m
@@ -45,12 +45,19 @@
         _rel = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"rel"];
         _type = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"type"];
         _version = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"version"];
-        _links = [aDecoder decodeObjectOfClass:[NSDictionary class] forKey:@"links"];
+
+        NSSet *validDataLinksClasses = [NSSet setWithArray:@[
+            [NSDictionary class],
+            [NSString class],
+        ]];
+        _links = [aDecoder decodeObjectOfClasses:validDataLinksClasses forKey:@"links"];
 
         NSSet *validDataClasses = [NSSet setWithArray:@[
             [NSMutableDictionary class],
             [NSArray class],
             [NSNull class],
+            [NSString class],
+            [NSNumber class],
         ]];
         _data = [aDecoder decodeObjectOfClasses:validDataClasses forKey:@"data"];
         NSSet *validCollectionJSONClasses = [NSSet setWithArray:@[


### PR DESCRIPTION
When the code is built using Xcode 13.2.1 a lot of warnings of this nature are seen:

```
[general] *** -[NSKeyedUnarchiver validateAllowedClass:forKey:] allowed unarchiving safe plist type ''NSString' (0x115ab2840) [/Users/isahashim/Downloads/XCODE/13.2.1/Xcode-13.2.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Foundation.framework]' for key 'NS.objects', even though it was not explicitly included in the client allowed classes set: '{(
    "'NSDictionary' (0x123495a30) [/Users/isahashim/Downloads/XCODE/13.2.1/Xcode-13.2.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework]"
)}'. This will be disallowed in the future.

[general] *** -[NSKeyedUnarchiver validateAllowedClass:forKey:] allowed unarchiving safe plist type ''NSString' (0x115ab2840) [/Users/isahashim/Downloads/XCODE/13.2.1/Xcode-13.2.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Foundation.framework]' for key 'NS.objects', even though it was not explicitly included in the client allowed classes set: '{(
    "'NSArray' (0x123495760) [/Users/isahashim/Downloads/XCODE/13.2.1/Xcode-13.2.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework]",
    "'NSMutableDictionary' (0x1234951e8) [/Users/isahashim/Downloads/XCODE/13.2.1/Xcode-13.2.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework]",
    "'NSNull' (0x123495e68) [/Users/isahashim/Downloads/XCODE/13.2.1/Xcode-13.2.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework]"
)}'. This will be disallowed in the future.

[general] *** -[NSKeyedUnarchiver validateAllowedClass:forKey:] allowed unarchiving safe plist type ''NSNumber' (0x115ab3538) [/Users/isahashim/Downloads/XCODE/13.2.1/Xcode-13.2.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Foundation.framework]' for key 'NS.objects', even though it was not explicitly included in the client allowed classes set: '{(
    "'NSArray' (0x123495760) [/Users/isahashim/Downloads/XCODE/13.2.1/Xcode-13.2.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework]",
    "'NSMutableDictionary' (0x1234951e8) [/Users/isahashim/Downloads/XCODE/13.2.1/Xcode-13.2.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework]",
    "'NSNull' (0x123495e68) [/Users/isahashim/Downloads/XCODE/13.2.1/Xcode-13.2.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework]"
)}'. This will be disallowed in the future.
```

The cause was found to be in TSDKCollectionJSON.initWithCoder()

No real logic change. Adding additional classes to the call to decodeObjectOfClasses() fixes the warnings.

I observe that the previous PRs did not update the podspec. This PR will be the same. The change is minor but the pod version will remain at 3.0.

I do notice that some tags and releases were created - I will add to that for this simple change to document why it was done.