### PR TITLE
[ISH-415] Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @teamsnap/bam-ios


### PR DESCRIPTION
This adds the CODEOWNERS file so that PRs will get automatically assigned to a review

If you feel like your team is the proper codeowner, then approve and merge this PR.

If you feel like your team is NOT the proper codeowner, comment back in the PR.