### PR TITLE
[CT-87] Add delete user call

### DIFF
--- a/TeamSnapSDK.podspec
+++ b/TeamSnapSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "TeamSnapSDK"
-  s.version      = "3.0"
+  s.version      = "3.1"
   s.summary      = "TeamSnap SDK for API v3"
   s.description  = "A library to access TeamSnap API v3"
   s.homepage     = "https://github.com/teamsnap/teamsnap-SDK-iOS"

--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.h
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.h
@@ -103,6 +103,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)saveObject:(TSDKCollectionObject *)object completion:(TSDKArrayCompletionBlock)completion;
 - (void)saveWithCustomURLQuery:(NSArray <NSURLQueryItem *> * )queryItems completion:(TSDKSaveCompletionBlock _Nullable)completion;
 - (void)saveWithURL:(NSURL * _Nonnull)url completion:(TSDKArrayCompletionBlock _Nullable)completion;
+- (void)deleteUserWithURL:(NSURL * _Nonnull)url completion:(TSDKArrayCompletionBlock _Nullable)completion;
 - (void)deleteWithCompletion:(TSDKSimpleCompletionBlock _Nullable)completion;
 
 - (void)refreshDataWithCompletion:(TSDKArrayCompletionBlock _Nullable)completion;

--- a/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.m
+++ b/TeamSnapSDK/SDK/CollectionJSON/TSDKCollectionObject.m
@@ -1140,6 +1140,15 @@ static void addImplementationForSelector(objc_property_t prop, SEL selector, Cla
     }
 }
 
+- (void)deleteUserWithURL:(NSURL *)url completion:(TSDKArrayCompletionBlock)completion {
+    __typeof__(self) __weak weakSelf = self;
+    [TSDKDataRequest requestObjectsForPath:url sendDataDictionary:nil method:@"POST" withConfiguration:[TSDKRequestConfiguration requestConfigurationWithForceReload:YES] completion:^(BOOL success, BOOL complete, TSDKCollectionJSON *objects, NSError *error) {
+            if (completion) {
+                completion(success, complete, @[weakSelf], error);
+            }
+    }];
+}
+
 - (void)deleteWithCompletion:(TSDKSimpleCompletionBlock)completion {
     if (self.isNewObject == NO) {
         NSDictionary *dataToSave = [self dataToSave];


### PR DESCRIPTION
Added a delete user call - my first attempt to piggyback off save had a problem. If a new object (ie. just created the user and deleted right away) it would correctly call URL with a "POST". However for an existing user it would call the URL with a "PATCH" which is incorrect. So made new call that just uses "POST" and is simpler than dealing with saveWithURL method.