### PR TITLE
feat: [PLAT-2922] reference GCS instead of rackspace

### DIFF
--- a/TeamSnapSDK.podspec
+++ b/TeamSnapSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "TeamSnapSDK"
-  s.version      = "3.9"
+  s.version      = "4.0"
   s.summary      = "TeamSnap SDK for API v3"
   s.description  = "A library to access TeamSnap API v3"
   s.homepage     = "https://github.com/teamsnap/teamsnap-SDK-iOS"

--- a/TeamSnapSDK/SDK/DataTypes/Media/TSDKTeamMedium.h
+++ b/TeamSnapSDK/SDK/DataTypes/Media/TSDKTeamMedium.h
@@ -15,7 +15,7 @@
 @property (nonatomic, strong) NSString *_Nullable teamMediumDescription; //Example: Ball
 @property (nonatomic, assign) NSInteger originalFileSize; //Example: 5176834
 @property (nonatomic, assign) NSInteger position; //Example: 1
-@property (nonatomic, strong) NSURL *_Nullable mediumUrl; //Example: https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/user_files/3263711/original/upload_133315715520120601-24224-1knpgia-0.jpg
+@property (nonatomic, strong) NSURL *_Nullable mediumUrl; //Example: https://storage.googleapis.com/ts_assets_prod-user_files/3263711/original/upload_133315715520120601-24224-1knpgia-0.jpg
 @property (nonatomic, strong) NSDate *_Nullable createdAt; //Example: 2012-03-31T01:27:34Z
 @property (nonatomic, strong) NSString *_Nullable teamMediaGroupId; //Example: 56194
 @property (nonatomic, strong) NSString *_Nullable mediaFormat; //Example: image

--- a/TeamSnapSDK/SDK/DataTypes/TSDKTslPhotos.h
+++ b/TeamSnapSDK/SDK/DataTypes/TSDKTslPhotos.h
@@ -13,7 +13,7 @@ typedef void (^ TSLImageUploadDetailsCompletionBlock)(BOOL success,NSURL *_Nulla
 
 @interface TSDKTslPhotos : TSDKCollectionObject
 
-@property (nonatomic, strong) NSString *_Nullable hostPrefix; //Example: https://7e7a37e9d371cdca79a5-2957068c55022fed6f3542268dd966e4.ssl.cf1.rackcdn.com
+@property (nonatomic, strong) NSString *_Nullable hostPrefix; //Example: https://storage.googleapis.com
 @property (nonatomic, strong) NSURL *_Nullable linkRoot;
 @property (nonatomic, strong) NSURL *_Nullable linkSelf;
 

--- a/TeamSnapSDK/SDK/Resources/schemas.json
+++ b/TeamSnapSDK/SDK/Resources/schemas.json
@@ -17774,7 +17774,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/1",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-basketball.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-basketball.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -17856,7 +17856,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/2",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-soccer.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-soccer.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -17938,7 +17938,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/4",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-softball.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-softball.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -18020,7 +18020,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/5",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-baseball.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-baseball.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -18102,7 +18102,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/6",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-volleyball.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-volleyball.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -18184,7 +18184,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/7",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-football.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-football.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -18266,7 +18266,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/8",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-cricket.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-cricket.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -18348,7 +18348,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/9",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-rugby.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-rugby.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -18430,7 +18430,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/10",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-lacrosse.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-lacrosse.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -18512,7 +18512,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/11",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-wiffleball.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-wiffleball.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -18594,7 +18594,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/13",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-bowling.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-bowling.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -18676,7 +18676,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/14",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-dodgeball.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-dodgeball.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -18758,7 +18758,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/15",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-field_hockey.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-field_hockey.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -18840,7 +18840,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/16",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-ice_hockey.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-ice_hockey.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -18922,7 +18922,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/17",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-inline_hockey.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-inline_hockey.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -19004,7 +19004,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/18",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-kickball.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-kickball.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -19086,7 +19086,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/19",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-paintball.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-paintball.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -19168,7 +19168,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/20",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-polo.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-polo.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -19250,7 +19250,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/21",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-rowing.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-rowing.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -19332,7 +19332,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/22",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-ultimate.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-ultimate.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -19414,7 +19414,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/23",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-water_polo.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-water_polo.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -19496,7 +19496,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/24",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-other_sport.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-other_sport.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -19578,7 +19578,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/25",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-dragon_boat.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-dragon_boat.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -19660,7 +19660,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/26",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-australian_football.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-australian_football.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -19742,7 +19742,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/27",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-badminton.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-badminton.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -19824,7 +19824,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/28",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-bandy.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-bandy.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -19906,7 +19906,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/29",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-bocce.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-bocce.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -19988,7 +19988,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/30",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-broomball.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-broomball.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -20070,7 +20070,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/31",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-cheerleading.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-cheerleading.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -20152,7 +20152,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/32",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-chess.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-chess.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -20234,7 +20234,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/33",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-croquet.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-croquet.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -20316,7 +20316,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/34",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-curling.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-curling.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -20398,7 +20398,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/35",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-cycling.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-cycling.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -20480,7 +20480,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/36",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-fencing.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-fencing.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -20562,7 +20562,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/37",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-foosball.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-foosball.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -20644,7 +20644,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/38",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-hurling.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-hurling.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -20726,7 +20726,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/39",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-indoor_soccer.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-indoor_soccer.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -20808,7 +20808,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/40",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-netball.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-netball.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -20890,7 +20890,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/41",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-running.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-running.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -20972,7 +20972,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/42",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-swimming.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-swimming.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -21054,7 +21054,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/43",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-tennis.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-tennis.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -21136,7 +21136,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/44",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-floorball.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-floorball.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -21218,7 +21218,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/45",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-petanque.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-petanque.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -21300,7 +21300,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/46",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-golf.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-golf.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -21382,7 +21382,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/47",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-sailing.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-sailing.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -21464,7 +21464,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/48",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-roller_derby.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-roller_derby.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -21546,7 +21546,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/49",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-wrestling.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-wrestling.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -21628,7 +21628,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/50",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-ki-o-rahi.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-ki-o-rahi.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -21710,7 +21710,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/51",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-ringette.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-ringette.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -21792,7 +21792,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/52",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-non-sport_group.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-non-sport_group.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -21874,7 +21874,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/53",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-outrigger.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-outrigger.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -21956,7 +21956,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/54",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-cow_tipping.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-cow_tipping.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -22038,7 +22038,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/55",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-racquetball.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-racquetball.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -22120,7 +22120,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/56",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-gymnastics-men.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-gymnastics-men.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -22202,7 +22202,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/57",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-gymnastics-women.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-gymnastics-women.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -22284,7 +22284,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/58",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-track_and_field.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-track_and_field.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -22366,7 +22366,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/59",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-archery.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-archery.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -22448,7 +22448,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/60",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-floor_hockey.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-floor_hockey.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -22530,7 +22530,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/61",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-slo-pitch.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-slo-pitch.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -22612,7 +22612,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/62",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-street_hockey.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-street_hockey.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -22694,7 +22694,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/63",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-pickleball.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-pickleball.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -22776,7 +22776,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/64",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-wheelchair_basketball.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-wheelchair_basketball.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -22858,7 +22858,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/65",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-sled_hockey.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-sled_hockey.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -22940,7 +22940,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/66",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-wheelchair_softball.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-wheelchair_softball.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -23022,7 +23022,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/67",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-quad_rugby.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-quad_rugby.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -23104,7 +23104,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/68",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-handcycling.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-handcycling.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -23186,7 +23186,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/69",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-adaptive_sports.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-adaptive_sports.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -23268,7 +23268,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/70",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-cross_country.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-cross_country.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -23350,7 +23350,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/71",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-cross_country_skiing.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-cross_country_skiing.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -23432,7 +23432,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/72",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-alpine_skiing.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-alpine_skiing.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -23514,7 +23514,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/73",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-wheelchair_hockey.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-wheelchair_hockey.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -23596,7 +23596,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/74",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-wheelchair_volleyball.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-wheelchair_volleyball.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -23678,7 +23678,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/75",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-wheelchair_lacrosse.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-wheelchair_lacrosse.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -23760,7 +23760,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/76",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-horseback_riding.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-horseback_riding.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -23842,7 +23842,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/77",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-diving.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-diving.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -23924,7 +23924,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/79",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-dance.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-dance.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -24006,7 +24006,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/82",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-quidditch.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-quidditch.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -24088,7 +24088,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/85",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-gymnastics-coed.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-gymnastics-coed.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -24170,7 +24170,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/88",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-musical_group.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-musical_group.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -24252,7 +24252,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/90",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-flying.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-flying.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -24334,7 +24334,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/93",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-darts.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-darts.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -24416,7 +24416,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/99",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-pool_and_billiards.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-pool_and_billiards.png",
                             "rel": "sport_logo"
                         }
                     ],
@@ -24498,7 +24498,7 @@
                     "href": "https://api.teamsnap.com/v3/sports/102",
                     "links": [
                         {
-                            "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-jump_rope.png",
+                            "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-jump_rope.png",
                             "rel": "sport_logo"
                         }
                     ],

--- a/TeamSnapSDK/SDK/Resources/sports.json
+++ b/TeamSnapSDK/SDK/Resources/sports.json
@@ -78,7 +78,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/69",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-adaptive_sports.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-adaptive_sports.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -160,7 +160,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/72",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-alpine_skiing.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-alpine_skiing.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -242,7 +242,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/59",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-archery.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-archery.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -324,7 +324,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/26",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-australian_football.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-australian_football.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -406,7 +406,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/27",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-badminton.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-badminton.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -488,7 +488,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/28",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-bandy.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-bandy.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -570,7 +570,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/5",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-baseball.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-baseball.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -652,7 +652,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/1",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-basketball.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-basketball.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -734,7 +734,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/29",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-bocce.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-bocce.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -816,7 +816,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/13",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-bowling.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-bowling.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -898,7 +898,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/30",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-broomball.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-broomball.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -980,7 +980,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/105",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-camogie.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-camogie.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -1062,7 +1062,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/31",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-cheerleading.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-cheerleading.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -1144,7 +1144,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/32",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-chess.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-chess.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -1226,7 +1226,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/54",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-cow_tipping.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-cow_tipping.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -1308,7 +1308,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/8",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-cricket.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-cricket.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -1390,7 +1390,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/33",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-croquet.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-croquet.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -1472,7 +1472,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/70",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-cross_country.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-cross_country.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -1554,7 +1554,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/71",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-cross_country_skiing.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-cross_country_skiing.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -1636,7 +1636,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/34",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-curling.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-curling.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -1718,7 +1718,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/35",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-cycling.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-cycling.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -1800,7 +1800,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/79",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-dance.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-dance.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -1882,7 +1882,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/93",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-darts.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-darts.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -1964,7 +1964,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/77",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-diving.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-diving.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -2046,7 +2046,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/14",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-dodgeball.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-dodgeball.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -2128,7 +2128,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/25",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-dragon_boat.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-dragon_boat.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -2210,7 +2210,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/36",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-fencing.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-fencing.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -2292,7 +2292,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/15",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-field_hockey.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-field_hockey.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -2374,7 +2374,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/119",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-figure_skating.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-figure_skating.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -2456,7 +2456,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/60",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-floor_hockey.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-floor_hockey.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -2538,7 +2538,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/44",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-floorball.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-floorball.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -2620,7 +2620,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/90",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-flying.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-flying.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -2702,7 +2702,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/37",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-foosball.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-foosball.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -2784,7 +2784,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/7",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-football.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-football.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -2866,7 +2866,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/137",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-gaelic_football.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-gaelic_football.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -2948,7 +2948,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/46",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-golf.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-golf.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -3030,7 +3030,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/85",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-gymnastics-coed.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-gymnastics-coed.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -3112,7 +3112,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/56",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-gymnastics-men.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-gymnastics-men.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -3194,7 +3194,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/57",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-gymnastics-women.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-gymnastics-women.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -3276,7 +3276,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/68",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-handcycling.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-handcycling.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -3358,7 +3358,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/76",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-horseback_riding.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-horseback_riding.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -3440,7 +3440,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/111",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-horseshoes.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-horseshoes.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -3522,7 +3522,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/38",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-hurling.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-hurling.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -3604,7 +3604,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/16",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-ice_hockey.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-ice_hockey.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -3686,7 +3686,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/39",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-indoor_soccer.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-indoor_soccer.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -3768,7 +3768,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/17",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-inline_hockey.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-inline_hockey.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -3850,7 +3850,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/102",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-jump_rope.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-jump_rope.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -3932,7 +3932,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/50",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-ki-o-rahi.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-ki-o-rahi.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -4014,7 +4014,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/18",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-kickball.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-kickball.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -4096,7 +4096,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/10",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-lacrosse.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-lacrosse.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -4178,7 +4178,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/128",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-martial_arts.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-martial_arts.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -4260,7 +4260,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/134",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-mixed_martial_arts.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-mixed_martial_arts.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -4342,7 +4342,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/88",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-musical_group.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-musical_group.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -4424,7 +4424,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/40",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-netball.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-netball.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -4506,7 +4506,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/52",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-non-sport_group.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-non-sport_group.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -4588,7 +4588,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/24",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-other_sport.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-other_sport.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -4670,7 +4670,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/53",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-outrigger.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-outrigger.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -4752,7 +4752,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/19",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-paintball.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-paintball.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -4834,7 +4834,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/45",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-petanque.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-petanque.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -4916,7 +4916,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/63",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-pickleball.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-pickleball.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -4998,7 +4998,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/20",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-polo.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-polo.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -5080,7 +5080,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/99",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-pool_and_billiards.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-pool_and_billiards.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -5162,7 +5162,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/67",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-quad_rugby.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-quad_rugby.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -5244,7 +5244,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/82",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-quidditch.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-quidditch.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -5326,7 +5326,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/55",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-racquetball.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-racquetball.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -5408,7 +5408,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/51",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-ringette.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-ringette.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -5490,7 +5490,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/48",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-roller_derby.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-roller_derby.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -5572,7 +5572,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/21",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-rowing.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-rowing.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -5654,7 +5654,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/9",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-rugby.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-rugby.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -5736,7 +5736,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/41",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-running.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-running.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -5818,7 +5818,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/47",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-sailing.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-sailing.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -5900,7 +5900,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/65",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-sled_hockey.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-sled_hockey.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -5982,7 +5982,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/61",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-slo-pitch.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-slo-pitch.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -6064,7 +6064,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/2",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-soccer.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-soccer.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -6146,7 +6146,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/4",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-softball.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-softball.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -6228,7 +6228,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/114",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-squash.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-squash.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -6310,7 +6310,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/62",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-street_hockey.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-street_hockey.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -6392,7 +6392,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/42",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-swimming.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-swimming.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -6474,7 +6474,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/116",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-synchronized_figure_skating.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-synchronized_figure_skating.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -6556,7 +6556,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/122",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-synchronized_swimming.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-synchronized_swimming.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -6638,7 +6638,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/43",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-tennis.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-tennis.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -6720,7 +6720,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/58",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-track_and_field.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-track_and_field.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -6802,7 +6802,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/22",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-ultimate.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-ultimate.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -6884,7 +6884,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/6",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-volleyball.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-volleyball.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -6966,7 +6966,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/23",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-water_polo.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-water_polo.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -7048,7 +7048,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/64",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-wheelchair_basketball.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-wheelchair_basketball.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -7130,7 +7130,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/73",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-wheelchair_hockey.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-wheelchair_hockey.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -7212,7 +7212,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/75",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-wheelchair_lacrosse.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-wheelchair_lacrosse.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -7294,7 +7294,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/66",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-wheelchair_softball.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-wheelchair_softball.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -7376,7 +7376,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/74",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-wheelchair_volleyball.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-wheelchair_volleyball.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -7458,7 +7458,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/11",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-wiffleball.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-wiffleball.png",
                         "rel": "sport_logo"
                     }
                 ],
@@ -7540,7 +7540,7 @@
                 "href": "https://api.teamsnap.com/v3/sports/49",
                 "links": [
                     {
-                        "href": "https://35b7f1d7d0790b02114c-1b8897185d70b198c119e1d2b7efd8a2.ssl.cf1.rackcdn.com/sport_logos/logo-wrestling.png",
+                        "href": "https://storage.googleapis.com/ts_assets_prod-sport_logos/logo-wrestling.png",
                         "rel": "sport_logo"
                     }
                 ],


### PR DESCRIPTION
Move rackspace references to GCS

**NOTE**: most of these references are already broken, a lot of the sport logos don't exist
